### PR TITLE
Revert "Update Helm release external-dns to v1.16.0"

### DIFF
--- a/charts/external-dns/Chart.yaml
+++ b/charts/external-dns/Chart.yaml
@@ -4,5 +4,5 @@ version: "1.0.0"
 
 dependencies:
   - name: external-dns
-    version: 1.16.0
+    version: 1.14.3
     repository: https://kubernetes-sigs.github.io/external-dns/


### PR DESCRIPTION
Reverts bdfrost/argocd#7