### PR TITLE
fix(kometa): add concurrencyPolicy Forbid to prevent pod pile-up

### DIFF
--- a/charts/kometa/cronjob.yaml
+++ b/charts/kometa/cronjob.yaml
@@ -5,6 +5,9 @@ metadata:
   namespace: kometa
 spec:
   schedule: "0 0 * * *"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 1
+  failedJobsHistoryLimit: 1
   jobTemplate:
     spec:
       template:


### PR DESCRIPTION
## Problem

The Kometa PVC `kometa-config-pvc-v2` got stuck in `Terminating` (deleted manually but held by the pvc-protection finalizer because 15+ CronJob-spawned pods reference it).

Every daily schedule run spawned a new pod that got stuck in `ContainerCreating` trying to mount the dying PVC — creating a cascading pile-up over ~15 days.

## Fix

- `concurrencyPolicy: Forbid` — prevents new jobs from starting while a previous run is still active or stuck
- `successfulJobsHistoryLimit: 1` — cleans up old completed Job pods
- `failedJobsHistoryLimit: 1` — cleans up old failed Job pods

## Additional manual steps needed

Once this merges (or directly):
```bash
# Suspend CronJob to stop the bleed
kubectl patch cronjob kometa -n kometa -p '{"spec":{"suspend":true}}'

# Delete stuck pods so PVC finalizer releases
kubectl delete pods -n kometa --field-selector=status.phase!=Succeeded

# PVC should finalize-delete, then ArgoCD recreates it fresh, then unsuspend
kubectl patch cronjob kometa -n kometa -p '{"spec":{"suspend":false}}'
```