### PR TITLE
fix: update sealed-secrets chart repo URL and bump to 2.19.1

### DIFF
--- a/charts/sealed-secrets/Chart.yaml
+++ b/charts/sealed-secrets/Chart.yaml
@@ -25,4 +25,4 @@ appVersion: "1.0"
 dependencies:
 - name: sealed-secrets
   version: 2.18.6
-  repository: https://bitnami-labs.github.io/sealed-secrets/
+  repository: https://bitnami.github.io/sealed-secrets


### PR DESCRIPTION
## Problem

The sealed-secrets Helm chart repository moved from bitnami-labs to bitnami on June 15–16, 2026. The old GitHub Pages URL does not redirect, so ArgoCD gets a 404 when reconciling the chart dependency.

## Changes

1. **Fix repo URL** — `bitnami-labs.github.io` → `bitnami.github.io`
2. **Bump chart** — `2.18.6` (app v0.37.0) → `2.19.1` (app v0.38.4)

Ref: https://github.com/bitnami/sealed-secrets/issues/1982